### PR TITLE
Clear database command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ Finally, change `MAIL_DRIVER` to `mailbase` in your `.env` file:
 ```
 MAIL_DRIVER=mailbase
 ```
+
+## Usage
+### Clearing Saved Emails
+If you want to clear any of the saved emails that are in the database, use the following command:
+```
+php artisan mailbase:clear
+```

--- a/src/MailbaseServiceProvider.php
+++ b/src/MailbaseServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Tkeer\Mailbase;
 
+use Tkeer\Mailbase\Commands\ClearMailbaseCommand;
 use Illuminate\Mail\MailServiceProvider;
 use Illuminate\Support\ServiceProvider;
 
@@ -22,9 +23,14 @@ class MailbaseServiceProvider extends ServiceProvider
             return new MailbaseTransport();
         });
 
-
         $this->loadMigrationsFrom(__DIR__ . '/migrations/');
         $this->loadRoutesFrom(__DIR__ . '/routes.php');
         $this->loadViewsFrom(__DIR__ . '/views', 'mailbase');
+
+        if($this->app->runningInConsole()) {
+            $this->commands([
+                ClearMailbaseCommand::class
+            ]);
+        }
     }
 }

--- a/src/commands/ClearMailbaseCommand.php
+++ b/src/commands/ClearMailbaseCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tkeer\Mailbase\Commands;
+
+use Illuminate\Console\Command;
+use Tkeer\Mailbase\Mailbase;
+
+class ClearMailbaseCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'mailbase:clear';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete all emails stored by Mailbase in the database.';
+
+    /**
+     * Execute the console command. Attempt to delete
+     * all of the Mailbase items stored in the DB.
+     * If an exception is thrown, catch it and
+     * display it in the console.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->line('Clearing stored Mailbase emails.');
+
+        try {
+            Mailbase::truncate();
+            $this->info('Cleared stored Mailbase emails.');
+        } catch (\Exception $exception) {
+            $this->error('Something went wrong while trying to clear the Mailbase table.');
+            $this->error($exception->getMessage());
+        }
+    }
+}

--- a/src/commands/ClearMailbaseCommand.php
+++ b/src/commands/ClearMailbaseCommand.php
@@ -33,12 +33,8 @@ class ClearMailbaseCommand extends Command
     {
         $this->line('Clearing stored Mailbase emails.');
 
-        try {
-            Mailbase::truncate();
-            $this->info('Cleared stored Mailbase emails.');
-        } catch (\Exception $exception) {
-            $this->error('Something went wrong while trying to clear the Mailbase table.');
-            $this->error($exception->getMessage());
-        }
+        Mailbase::truncate();
+
+        $this->info('Cleared stored Mailbase emails.');
     }
 }


### PR DESCRIPTION
Hi,

This pull request adds a command that can be used to clear all of the stored Mailbase items in the database. It's something that I think I'd use quite often if I use this package in future projects.

I've also updated the README file to give instructions. It's a quick, simple command:
```
php artisan mailbase:clear
```

If you'd like anything changing so that it can be pulled in, I'd be happy to make any changes :)